### PR TITLE
Small bugfix

### DIFF
--- a/lib/expectr.rb
+++ b/lib/expectr.rb
@@ -259,6 +259,7 @@ class Expectr
 							@out_update = false
 						end
 					end
+					sleep 0.1
 				end
 			end
 


### PR DESCRIPTION
Hi,

Please consider my bugfix or find another resolution of problem. The 'while' loop that waits for matching expectation has no delay and eats 100% cpu until timeout occurs.

Best regards,

Adrian
