### PR TITLE
Fix process_procmap pattern and recoverable issues

### DIFF
--- a/lib/expectr.rb
+++ b/lib/expectr.rb
@@ -381,8 +381,9 @@ class Expectr
       c += "|" unless c.empty?
       c + "(#{e.source})"
     end
+    pattern = Regexp.new(pattern)
 
-    recoverable = regex_keys.include?(:default) || regex_keys.include?(:timeout)
+    recoverable = pattern_map.keys.include?(:default) || pattern_map.keys.include?(:timeout)
 
     return pattern_map, pattern, recoverable
   end


### PR DESCRIPTION
I apologize in advanced if I'm doing something incorrectly because this is the first time I'm submitting a pull request on Github! I had a couple of issues with your code so I made a couple of small changes in expect.rb that fixed them. 
1.  In process_procmap - the pattern that is returned is a string, however a regex is expected. I fixed this on line 384.
2. In process_procmap - recoverable will always be false as regex_keys is ONLY regexes (done on line 379). pattern_map.keys has the symbols still and so I replaced regex_keys on line 385 with that. 
